### PR TITLE
Implemented the limitations of requests per minute

### DIFF
--- a/cinemy/cinemy/settings.py
+++ b/cinemy/cinemy/settings.py
@@ -13,7 +13,6 @@ https://docs.djangoproject.com/en/4.0/ref/settings/
 import os
 from pathlib import Path
 import environ
-import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent

--- a/cinemy/contact/views.py
+++ b/cinemy/contact/views.py
@@ -4,8 +4,10 @@ from django.shortcuts import redirect, render
 from contact.forms import ContactForm
 from django.core.mail import send_mail
 from django.contrib import messages
+from ratelimit.decorators import ratelimit
 
 
+@ratelimit(key="ip", rate="2/m", block=True)
 def contact_page(request):
     if request.method == "GET":
         return render(request, "contact/contact.html")

--- a/cinemy/core/views.py
+++ b/cinemy/core/views.py
@@ -2,10 +2,12 @@ from datetime import datetime
 from django.shortcuts import render
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from core.models import Movie
+from ratelimit.decorators import ratelimit
 
 # Create your views here.
 
 
+@ratelimit(key="ip", rate="30/m", block=True)
 def front_page(request):
     if request.method == "GET":
         movies = Movie.objects.filter(available_from__lte=datetime.today())

--- a/cinemy/login/urls.py
+++ b/cinemy/login/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path, include, re_path
+from django.urls import path
 from login.views import activate, signup, auth
 
 urlpatterns = [

--- a/cinemy/login/views.py
+++ b/cinemy/login/views.py
@@ -16,8 +16,10 @@ from django.contrib.sites.shortcuts import get_current_site
 from login.tokens import account_activation_token
 from django.utils.encoding import force_str
 from django.contrib.auth import get_user_model
+from ratelimit.decorators import ratelimit
 
 
+@ratelimit(key="ip", rate="30/m", block=True)
 def auth(request):
     if request.method == "POST":
         username = request.POST["username"]
@@ -32,6 +34,7 @@ def auth(request):
     return render(request, "login/login.html")
 
 
+@ratelimit(key="ip", rate="30/m", block=True)
 def signup(request):
     if request.method == "POST":
         try:


### PR DESCRIPTION
- Added a ratelimit of 30 requests per minute for the front page and 2 requests per minute for the contact page
- Removed some unused imports