### PR TITLE
Added playing time endpoint

### DIFF
--- a/cinemy/cinema/serializers.py
+++ b/cinemy/cinema/serializers.py
@@ -1,4 +1,3 @@
-from rest_framework import response, status
 from rest_framework import serializers
 from cinema.models import Movie, PlayingTime, Hall, Cinema
 

--- a/cinemy/cinema/serializers.py
+++ b/cinemy/cinema/serializers.py
@@ -1,3 +1,4 @@
+from rest_framework import response, status
 from rest_framework import serializers
 from cinema.models import Movie, PlayingTime, Hall, Cinema
 
@@ -11,7 +12,7 @@ class CinemaSerializer(serializers.ModelSerializer):
 class MovieSerializer(serializers.ModelSerializer):
     class Meta:
         model = Movie
-        exclude = ("id",)
+        fields = "__all__"
 
 
 class HallSerializer(serializers.ModelSerializer):
@@ -39,7 +40,24 @@ class PlayingTimeSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = PlayingTime
-        exclude = ("id",)
+        fields = ("hall", "movie", "start_time", "id")
+
+
+class PlayingTimeCreateSerializer(serializers.Serializer):
+    hall = serializers.IntegerField()
+    movie = serializers.IntegerField()
+    start_time = serializers.DateTimeField()
+
+    def perform_create(self, serializer):
+        return serializer.save(user=self.request.user)
+
+    def create(self, validated_data):
+        instance = PlayingTime.objects.create(
+            assigned_movie_id=validated_data["movie"],
+            assigned_hall_id=validated_data["hall"],
+            start_time=validated_data["start_time"],
+        )
+        return instance
 
 
 class DetailedMovieSerializer(serializers.ModelSerializer):

--- a/cinemy/cinema/urls.py
+++ b/cinemy/cinema/urls.py
@@ -15,6 +15,7 @@ from cinema.viewset import (
     SearchMovieViewSet,
     HallViewSet,
     MovieViewSet,
+    PlayingTimeViewSet,
 )
 
 router = DefaultRouter()
@@ -29,6 +30,7 @@ router.register(
 router.register("search-movies", SearchMovieViewSet, "search-movies")
 router.register("hall", HallViewSet, "hall")
 router.register("movie", MovieViewSet, "movie")
+router.register("playing-time", PlayingTimeViewSet, "playing-time")
 
 urlpatterns = [
     path("book_a_ticket/select_cinema/", select_cinema, name="select_cinema"),


### PR DESCRIPTION
- For the creation part, another serializer is used so that the user can create the PlayingTime only by specifying the hall and movies id in this format:
`{
    "hall": 8,
    "movie":25,
    "start_time":"2022-07-24T12:42:25Z"
}`
- The typo in the auth mixin was fixed